### PR TITLE
Separate out buffer management into its own class

### DIFF
--- a/onnx_halide/buffer_manager.py
+++ b/onnx_halide/buffer_manager.py
@@ -1,0 +1,35 @@
+from .types import VI
+from typing import Dict
+from onnx.onnx_ml_pb2 import TypeProto
+
+
+class BufferManager:
+    def __init__(self, value_info: Dict[str, TypeProto]):
+        self.value_info = value_info
+    '''Tracks and allocates buffers, reusing them when possible.
+    Currently supported modes are "naive" (always allocate new),
+    and "double buffer'''
+    def allocate_buffer(self, op: str) -> str:
+        raise Exception('Cannot use abstract allocator ')
+
+class Buffer:
+    bufferCount = 0
+    @classmethod
+    def allocBuffer(cls) -> str:
+        cls.bufferCount += 1
+        return "buffer{}".format(str(cls.bufferCount))
+    def __init__(self, c_type: str, size: int, name = None):
+        self.c_type = c_type
+        self.size = size
+        self.name = name if name is not None else Buffer.allocBuffer()
+
+class NaiveBufferManager(BufferManager):
+    '''Allocate a new buffer for each output'''
+
+    def allocate_buffer(self, op: str) -> str:
+        '''Prefix with a v_ to avoid invalid token in C'''
+        op_shape = VI(self.value_info[op]).shape
+        return "  {0}* v_{1} = ({0}*) malloc({2}*sizeof({0}));".format(
+            VI(self.value_info[op]).t.c,
+            op,
+            "*".join(map(str, op_shape)) if op_shape else "1")


### PR DESCRIPTION
This allows us to plug in different allocation strategies (naive, double buffering, etc.) relatively easily. I also tested out double buffering and it worked fine, but since it's utility was limited to very simple graphs it's not included in this commit. 

I'm not sure if we might want to expand the scope of this to also cover allocation for the graph's input/output buffers.

Additionally, depending on how we plan to do the variable name sanitization later on, we might consider having all calls to get the buffer name for a given node's output go through this class. That would free us from the need to insert the `float * newOutputBuffer = oldOutputBuffer` type calls in `generated.c` since we could just refer the old buffer directly in generated code, and it would also allow sanitization to be done at a central place [assuming we don't instead just add a pre-pass at the beginning doing all the sanitization].
